### PR TITLE
Add readiness and liveness endpoints

### DIFF
--- a/product-service/src/main/resources/application.yaml
+++ b/product-service/src/main/resources/application.yaml
@@ -21,3 +21,8 @@ management:
     web:
       exposure:
         include: health,prometheus
+  endpoint:
+    health:
+      probes.enabled: true
+      group.readiness.include: mongo
+


### PR DESCRIPTION
### Liveness and readiness probes

a liveness probe tells Kubernetes if a Pod needs to be replaced and a readiness probe tells Kubernetes if its Pod is ready to accept requests

```
management.endpoint.health.probes.enabled: true
management.endpoint.health.group.readiness.include: mongo
```

The first line of the configuration enables the liveness and readiness probes. The second line declares that readiness probes will include health indicators for RabbitMQ, MongoDB, and SQL databases, if available. For the liveness probe, we don't need to add any extra health indicators. For the scope of this chapter, it is sufficient that the liveness probe reports UP given that the Spring Boot application is up and running.

If we for example stop the mongo service and check the readiness state we will get the status
```
{
    "status": "DOWN"
}
```
