### PR TITLE
Upgrade to Spring Boot 4.0.5, Java 25, and Gradle 9.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,82 +1,44 @@
 ## Architecture
 ![](./static/images/project-architecture.drawio.svg)
 
-## Tech Stack
-| Component | Technology |
-|---|---|
-| Language | Java 25 |
-| Framework | Spring Boot 4.0.5 |
-| Service Discovery | Spring Cloud Netflix Eureka |
-| API Gateway | Spring Cloud Gateway (WebFlux) |
-| Security | Spring Security + JWT |
-| Circuit Breaker | Resilience4j |
-| Databases | MySQL, MongoDB |
-| Tracing | Zipkin + Micrometer Brave |
-| Metrics | Prometheus + Grafana |
-| Build Tool | Gradle 9.4.1 |
-| Container | Docker + Docker Compose |
+## Run project using docker
+```commandline
+docker compose up -d --build
+```
 
-## Prerequisites
-- [Docker](https://docs.docker.com/get-docker/) (with Docker Compose plugin)
+## Run project manually
+If you want to run locally, do following steps
+1. Run required dependencies
+```commandline
+ docker-compose -f docker-compose-local.yml up -d
+```
+2. Run services in the following order
+- discovery-server (uses port:8761)
+- api-gateway (uses port: 8080)
+- product-service (uses port: 8081)
+- inventory-service (uses port: 8083)
+- order-service (uses port: 8080)
+- run funnel-service (uses port: 8000) (Service with different framework)
+  ```agsl
+    cd funnel-service
+    pip install -r requirement.txt
+    uvicorn main:app --reload
+    ```
 
-> No local Java installation required — the Docker build compiles the source inside the container.
+## Check if api-gateway is working fine
 
-## Run project using Docker
+### Login
 ```bash
-sh run-project.sh
-```
-This will build all services from source and start the full stack.
+curl -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username": "binod", "password": "binod"}'
+  ```
 
-| Service | URL |
-|---|---|
-| API Gateway | http://localhost:8080 |
-| Eureka Dashboard | http://localhost:8761 |
-| Zipkin | http://localhost:9411 |
-| Prometheus | http://localhost:9090 |
-| Grafana | http://localhost:3000 |
-
-## Run project manually (without Docker)
-
-### Prerequisites
-- Java 25
-- Docker (for dependencies)
-
-### Steps
-1. Start required dependencies (MySQL, MongoDB, Zipkin, etc.)
-```bash
-docker compose -f docker-compose-local.yml up -d
-```
-
-2. Run services in the following order:
-   - `discovery-server` (port: 8761)
-   - `api-gateway` (port: 8080)
-   - `product-service` (port: 8081)
-   - `inventory-service` (port: 8083)
-   - `order-service` (port: 8082)
-
-3. Run `funnel-service` (port: 8000) — Python service
-```bash
-cd funnel-service
-pip install -r requirement.txt
-uvicorn main:app --reload
-```
-
-## API Reference
-
-### Authentication
-All endpoints (except login) require a Bearer JWT token.
-
-**POST** `localhost:8080/api/auth/login`
-```json
-{
-    "username": "binod",
-    "password": "binod"
-}
-```
+Authorization type: Bearer token
 
 ### product-service
+POST: localhost:8080/api/product
 
-**POST** `localhost:8080/api/product`
 ```json
 {
     "name": "iPhone",
@@ -85,8 +47,10 @@ All endpoints (except login) require a Bearer JWT token.
 }
 ```
 
-**GET** `localhost:8080/api/product`
-```json
+GET: localhost:8080/api/product
+
+Response:
+```agsl
 [
     {
         "id": "66d7ee3bd482852c6e6c93c3",
@@ -97,25 +61,26 @@ All endpoints (except login) require a Bearer JWT token.
 ]
 ```
 
-### order-service
+### order-service with inventory-service
 
-**POST** `localhost:8080/api/order`
+POST: localhost:8080/api/order
 ```json
 {
-  "orderLineItems": [
+  "orderLineItems":  [
     {
-      "id": 1,
-      "skuCode": "iphone_13",
-      "quantity": 10,
-      "price": 120
+    "id": 1, 
+    "skuCode": "iphone_13",
+    "quantity": 10,
+    "price": 120
     }
-  ]
+]
 }
 ```
 
-### funnel-service
+### Service with different framework
+GET: localhost:8080/api/funnel
 
-**GET** `localhost:8080/api/funnel`
+expected response:
 ```json
 {
     "message": "Hello I am from funnel service"
@@ -126,11 +91,12 @@ All endpoints (except login) require a Bearer JWT token.
 
 ![](./static/images/grafana-monitor-diagram.drawio.svg)
 
-- Spring Boot exposes metrics via Actuator endpoints
-- Prometheus scrapes metrics at a regular interval (configured in `prometheus/prometheus.yml`)
-- Grafana visualizes the data from Prometheus
+- Spring-boot app will expose metrics via actuator endpoints.
+- Prometheus polls for the metrics at a regular interval configured in prometheus.yml
+- Prometheus stores the metrics which acts as datasource for the grafana
+- Grafana polls the data from prometheus at a regular interval and display on the dashboard
 
-### Setting up Grafana
-1. Open Grafana at http://localhost:3000 (admin / admin)
-2. Add a Prometheus data source with URL: `http://prometheus:9090`
-3. Import the dashboard from `grafana_dashboard.json`
+## Create a grafana dash-board
+- Add data source
+- Set prometheus url: http://prometheus:9090
+- Create dashboard by importing json `grafana_dashboard.json`

--- a/README.md
+++ b/README.md
@@ -1,47 +1,82 @@
 ## Architecture
 ![](./static/images/project-architecture.drawio.svg)
 
-## Run project using docker
-```commandline
+## Tech Stack
+| Component | Technology |
+|---|---|
+| Language | Java 25 |
+| Framework | Spring Boot 4.0.5 |
+| Service Discovery | Spring Cloud Netflix Eureka |
+| API Gateway | Spring Cloud Gateway (WebFlux) |
+| Security | Spring Security + JWT |
+| Circuit Breaker | Resilience4j |
+| Databases | MySQL, MongoDB |
+| Tracing | Zipkin + Micrometer Brave |
+| Metrics | Prometheus + Grafana |
+| Build Tool | Gradle 9.4.1 |
+| Container | Docker + Docker Compose |
+
+## Prerequisites
+- [Docker](https://docs.docker.com/get-docker/) (with Docker Compose plugin)
+
+> No local Java installation required — the Docker build compiles the source inside the container.
+
+## Run project using Docker
+```bash
 sh run-project.sh
 ```
+This will build all services from source and start the full stack.
 
-## Run project manually
-If you want to run locally, do following steps
-1. Run required dependencies
-```commandline
- docker-compose -f docker-compose-local.yml up -d
+| Service | URL |
+|---|---|
+| API Gateway | http://localhost:8080 |
+| Eureka Dashboard | http://localhost:8761 |
+| Zipkin | http://localhost:9411 |
+| Prometheus | http://localhost:9090 |
+| Grafana | http://localhost:3000 |
+
+## Run project manually (without Docker)
+
+### Prerequisites
+- Java 25
+- Docker (for dependencies)
+
+### Steps
+1. Start required dependencies (MySQL, MongoDB, Zipkin, etc.)
+```bash
+docker compose -f docker-compose-local.yml up -d
 ```
-2. Run services in the following order
-- discovery-server (uses port:8761)
-- api-gateway (uses port: 8080)
-- product-service (uses port: 8081)
-- inventory-service (uses port: 8083)
-- order-service (uses port: 8080)
-- run funnel-service (uses port: 8000) (Service with different framework)
-  ```agsl
-    cd funnel-service
-    pip install -r requirement.txt
-    uvicorn main:app --reload
-    ```
 
-## Check if api-gateway is working fine
+2. Run services in the following order:
+   - `discovery-server` (port: 8761)
+   - `api-gateway` (port: 8080)
+   - `product-service` (port: 8081)
+   - `inventory-service` (port: 8083)
+   - `order-service` (port: 8082)
 
-### Login
-POST: localhost:8080/api/auth/login
+3. Run `funnel-service` (port: 8000) — Python service
+```bash
+cd funnel-service
+pip install -r requirement.txt
+uvicorn main:app --reload
+```
+
+## API Reference
+
+### Authentication
+All endpoints (except login) require a Bearer JWT token.
+
+**POST** `localhost:8080/api/auth/login`
 ```json
 {
     "username": "binod",
     "password": "binod"
 }
 ```
-For each request accept login, we need jwt token which we can get from the `/api/auth/login` api above.
-
-Authorization type: Bearer token
 
 ### product-service
-POST: localhost:8080/api/product
 
+**POST** `localhost:8080/api/product`
 ```json
 {
     "name": "iPhone",
@@ -50,10 +85,8 @@ POST: localhost:8080/api/product
 }
 ```
 
-GET: localhost:8080/api/product
-
-Response:
-```agsl
+**GET** `localhost:8080/api/product`
+```json
 [
     {
         "id": "66d7ee3bd482852c6e6c93c3",
@@ -64,26 +97,25 @@ Response:
 ]
 ```
 
-### order-service with inventory-service
+### order-service
 
-POST: localhost:8080/api/order
+**POST** `localhost:8080/api/order`
 ```json
 {
-  "orderLineItems":  [
+  "orderLineItems": [
     {
-    "id": 1, 
-    "skuCode": "iphone_13",
-    "quantity": 10,
-    "price": 120
+      "id": 1,
+      "skuCode": "iphone_13",
+      "quantity": 10,
+      "price": 120
     }
-]
+  ]
 }
 ```
 
-### Service with different framework
-GET: localhost:8080/api/funnel
+### funnel-service
 
-expected response:
+**GET** `localhost:8080/api/funnel`
 ```json
 {
     "message": "Hello I am from funnel service"
@@ -94,12 +126,11 @@ expected response:
 
 ![](./static/images/grafana-monitor-diagram.drawio.svg)
 
-- Spring-boot app will expose metrics via actuator endpoints.
-- Prometheus polls for the metrics at a regular interval configured in prometheus.yml
-- Prometheus stores the metrics which acts as datasource for the grafana
-- Grafana polls the data from prometheus at a regular interval and display on the dashboard
+- Spring Boot exposes metrics via Actuator endpoints
+- Prometheus scrapes metrics at a regular interval (configured in `prometheus/prometheus.yml`)
+- Grafana visualizes the data from Prometheus
 
-## Create a grafana dash-board
-- Add data source
-- Set prometheus url: http://prometheus:9090
-- Create dashboard by importing json `grafana_dashboard.json`
+### Setting up Grafana
+1. Open Grafana at http://localhost:3000 (admin / admin)
+2. Add a Prometheus data source with URL: `http://prometheus:9090`
+3. Import the dashboard from `grafana_dashboard.json`

--- a/README.md
+++ b/README.md
@@ -1,44 +1,82 @@
 ## Architecture
 ![](./static/images/project-architecture.drawio.svg)
 
-## Run project using docker
-```commandline
-docker compose up -d --build
-```
+## Tech Stack
+| Component | Technology |
+|---|---|
+| Language | Java 25 |
+| Framework | Spring Boot 4.0.5 |
+| Service Discovery | Spring Cloud Netflix Eureka |
+| API Gateway | Spring Cloud Gateway (WebFlux) |
+| Security | Spring Security + JWT |
+| Circuit Breaker | Resilience4j |
+| Databases | MySQL, MongoDB |
+| Tracing | Zipkin + Micrometer Brave |
+| Metrics | Prometheus + Grafana |
+| Build Tool | Gradle 9.4.1 |
+| Container | Docker + Docker Compose |
 
-## Run project manually
-If you want to run locally, do following steps
-1. Run required dependencies
-```commandline
- docker-compose -f docker-compose-local.yml up -d
-```
-2. Run services in the following order
-- discovery-server (uses port:8761)
-- api-gateway (uses port: 8080)
-- product-service (uses port: 8081)
-- inventory-service (uses port: 8083)
-- order-service (uses port: 8080)
-- run funnel-service (uses port: 8000) (Service with different framework)
-  ```agsl
-    cd funnel-service
-    pip install -r requirement.txt
-    uvicorn main:app --reload
-    ```
+## Prerequisites
+- [Docker](https://docs.docker.com/get-docker/) (with Docker Compose plugin)
 
-## Check if api-gateway is working fine
+> No local Java installation required — the Docker build compiles the source inside the container.
 
-### Login
+## Run project using Docker
 ```bash
-curl -X POST http://localhost:8080/api/auth/login \
-  -H "Content-Type: application/json" \
-  -d '{"username": "binod", "password": "binod"}'
-  ```
+sh run-project.sh
+```
+This will build all services from source and start the full stack.
 
-Authorization type: Bearer token
+| Service | URL |
+|---|---|
+| API Gateway | http://localhost:8080 |
+| Eureka Dashboard | http://localhost:8761 |
+| Zipkin | http://localhost:9411 |
+| Prometheus | http://localhost:9090 |
+| Grafana | http://localhost:3000 |
+
+## Run project manually (without Docker)
+
+### Prerequisites
+- Java 25
+- Docker (for dependencies)
+
+### Steps
+1. Start required dependencies (MySQL, MongoDB, Zipkin, etc.)
+```bash
+docker compose -f docker-compose-local.yml up -d
+```
+
+2. Run services in the following order:
+   - `discovery-server` (port: 8761)
+   - `api-gateway` (port: 8080)
+   - `product-service` (port: 8081)
+   - `inventory-service` (port: 8083)
+   - `order-service` (port: 8082)
+
+3. Run `funnel-service` (port: 8000) — Python service
+```bash
+cd funnel-service
+pip install -r requirement.txt
+uvicorn main:app --reload
+```
+
+## API Reference
+
+### Authentication
+All endpoints (except login) require a Bearer JWT token.
+
+**POST** `localhost:8080/api/auth/login`
+```json
+{
+    "username": "binod",
+    "password": "binod"
+}
+```
 
 ### product-service
-POST: localhost:8080/api/product
 
+**POST** `localhost:8080/api/product`
 ```json
 {
     "name": "iPhone",
@@ -47,10 +85,8 @@ POST: localhost:8080/api/product
 }
 ```
 
-GET: localhost:8080/api/product
-
-Response:
-```agsl
+**GET** `localhost:8080/api/product`
+```json
 [
     {
         "id": "66d7ee3bd482852c6e6c93c3",
@@ -61,26 +97,25 @@ Response:
 ]
 ```
 
-### order-service with inventory-service
+### order-service
 
-POST: localhost:8080/api/order
+**POST** `localhost:8080/api/order`
 ```json
 {
-  "orderLineItems":  [
+  "orderLineItems": [
     {
-    "id": 1, 
-    "skuCode": "iphone_13",
-    "quantity": 10,
-    "price": 120
+      "id": 1,
+      "skuCode": "iphone_13",
+      "quantity": 10,
+      "price": 120
     }
-]
+  ]
 }
 ```
 
-### Service with different framework
-GET: localhost:8080/api/funnel
+### funnel-service
 
-expected response:
+**GET** `localhost:8080/api/funnel`
 ```json
 {
     "message": "Hello I am from funnel service"
@@ -91,12 +126,11 @@ expected response:
 
 ![](./static/images/grafana-monitor-diagram.drawio.svg)
 
-- Spring-boot app will expose metrics via actuator endpoints.
-- Prometheus polls for the metrics at a regular interval configured in prometheus.yml
-- Prometheus stores the metrics which acts as datasource for the grafana
-- Grafana polls the data from prometheus at a regular interval and display on the dashboard
+- Spring Boot exposes metrics via Actuator endpoints
+- Prometheus scrapes metrics at a regular interval (configured in `prometheus/prometheus.yml`)
+- Grafana visualizes the data from Prometheus
 
-## Create a grafana dash-board
-- Add data source
-- Set prometheus url: http://prometheus:9090
-- Create dashboard by importing json `grafana_dashboard.json`
+### Setting up Grafana
+1. Open Grafana at http://localhost:3000 (admin / admin)
+2. Add a Prometheus data source with URL: `http://prometheus:9090`
+3. Import the dashboard from `grafana_dashboard.json`

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,12 +1,30 @@
-FROM eclipse-temurin:17.0.4.1_1-jre as builder
-WORKDIR extracted
-ADD build/libs/*.jar app.jar
-RUN java -Djarmode=layertools -jar app.jar extract
+FROM azul/zulu-openjdk-alpine:25 AS builder
+WORKDIR /var/tmp/api-gateway
+COPY gradlew gradlew
+COPY gradle/wrapper gradle/wrapper
 
-FROM eclipse-temurin:17.0.4.1_1-jre
-WORKDIR application
-COPY --from=builder extracted/dependencies/ ./
-COPY --from=builder extracted/spring-boot-loader/ ./
-COPY --from=builder extracted/snapshot-dependencies/ ./
-COPY --from=builder extracted/application/ ./
-ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+RUN ./gradlew --version
+COPY build.gradle .
+COPY settings.gradle .
+COPY api-gateway/build.gradle api-gateway/build.gradle
+COPY discovery-server/build.gradle discovery-server/build.gradle
+COPY inventory-service/build.gradle inventory-service/build.gradle
+COPY order-service/build.gradle order-service/build.gradle
+COPY product-service/build.gradle product-service/build.gradle
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :api-gateway:dependencies --no-daemon --parallel --build-cache
+
+COPY api-gateway/src api-gateway/src
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :api-gateway:bootJar --no-daemon --parallel --build-cache
+RUN java -Djarmode=tools -jar api-gateway/build/libs/api-gateway.jar extract --destination extracted
+
+FROM azul/zulu-openjdk-alpine:25-jre
+WORKDIR /root
+COPY --from=builder /var/tmp/api-gateway/extracted/api-gateway.jar ./
+COPY --from=builder /var/tmp/api-gateway/extracted/lib ./lib
+
+EXPOSE 8080
+CMD ["java", "-jar", "./api-gateway.jar"]

--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/api-gateway/src/main/java/com/bebit/apigateway/ApiGatewayApplication.java
+++ b/api-gateway/src/main/java/com/bebit/apigateway/ApiGatewayApplication.java
@@ -18,7 +18,10 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-@SpringBootApplication
+@SpringBootApplication(excludeName = {
+    "org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration",
+    "org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration"
+})
 @EnableDiscoveryClient
 public class ApiGatewayApplication {
 

--- a/api-gateway/src/main/java/com/bebit/apigateway/security/config/SecurityConfig.java
+++ b/api-gateway/src/main/java/com/bebit/apigateway/security/config/SecurityConfig.java
@@ -68,9 +68,9 @@ public class SecurityConfig {
           auth.anyExchange().authenticated();
         })
         .addFilterAt(jwtFilter, SecurityWebFiltersOrder.AUTHENTICATION)
-        .httpBasic().disable()
-        .formLogin().disable()
-        .csrf().disable()
+        .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+        .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+        .csrf(ServerHttpSecurity.CsrfSpec::disable)
         .build();
 
   }

--- a/api-gateway/src/main/resources/application.yaml
+++ b/api-gateway/src/main/resources/application.yaml
@@ -3,6 +3,8 @@ eureka:
     serviceUrl:
       defaultZone: http://localhost:8761/eureka/
 spring:
+  main:
+    web-application-type: reactive
   application:
     name: api-gateway
   datasource:

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.0.2'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot' version '4.0.5'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 repositories {
     mavenCentral()
 }
 
 ext {
-    set('springCloudVersion', "2022.0.0")
+    set('springCloudVersion', "2025.1.1")
 }
 
 bootJar {
@@ -23,7 +23,7 @@ subprojects {
 
     java {
         toolchain {
-            languageVersion = JavaLanguageVersion.of(17)
+            languageVersion = JavaLanguageVersion.of(25)
         }
     }
 

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -1,12 +1,30 @@
-FROM eclipse-temurin:17.0.4.1_1-jre as builder
-WORKDIR extracted
-ADD build/libs/*.jar app.jar
-RUN java -Djarmode=layertools -jar app.jar extract
+FROM azul/zulu-openjdk-alpine:25 AS builder
+WORKDIR /var/tmp/discovery-server
+COPY gradlew gradlew
+COPY gradle/wrapper gradle/wrapper
 
-FROM eclipse-temurin:17.0.4.1_1-jre
-WORKDIR application
-COPY --from=builder extracted/dependencies/ ./
-COPY --from=builder extracted/spring-boot-loader/ ./
-COPY --from=builder extracted/snapshot-dependencies/ ./
-COPY --from=builder extracted/application/ ./
-ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+RUN ./gradlew --version
+COPY build.gradle .
+COPY settings.gradle .
+COPY api-gateway/build.gradle api-gateway/build.gradle
+COPY discovery-server/build.gradle discovery-server/build.gradle
+COPY inventory-service/build.gradle inventory-service/build.gradle
+COPY order-service/build.gradle order-service/build.gradle
+COPY product-service/build.gradle product-service/build.gradle
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :discovery-server:dependencies --no-daemon --parallel --build-cache
+
+COPY discovery-server/src discovery-server/src
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :discovery-server:bootJar --no-daemon --parallel --build-cache
+RUN java -Djarmode=tools -jar discovery-server/build/libs/discovery-server.jar extract --destination extracted
+
+FROM azul/zulu-openjdk-alpine:25-jre
+WORKDIR /root
+COPY --from=builder /var/tmp/discovery-server/extracted/discovery-server.jar ./
+COPY --from=builder /var/tmp/discovery-server/extracted/lib ./lib
+
+EXPOSE 8080
+CMD ["java", "-jar", "./discovery-server.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   mysql:
     container_name: mysql
@@ -27,7 +26,8 @@ services:
   discovery-server:
     container_name: eureka
     build:
-      context: discovery-server
+      context: .
+      dockerfile: discovery-server/Dockerfile
     ports:
       - "8761:8761"
     environment:
@@ -35,7 +35,8 @@ services:
   api-gateway:
     container_name: api-gateway
     build:
-      context: api-gateway
+      context: .
+      dockerfile: api-gateway/Dockerfile
     ports:
       - "8080:8080"
     expose:
@@ -50,7 +51,8 @@ services:
   product-service:
     container_name: product-service
     build:
-      context: product-service
+      context: .
+      dockerfile: product-service/Dockerfile
     restart: always
     environment:
       - SPRING_PROFILES_ACTIVE=docker
@@ -62,7 +64,8 @@ services:
   order-service:
     container_name: order-service
     build:
-      context: order-service
+      context: .
+      dockerfile: order-service/Dockerfile
     restart: always
     environment:
       - SPRING_PROFILES_ACTIVE=docker
@@ -75,7 +78,8 @@ services:
   inventory-service:
     container_name: inventory-service
     build:
-      context: inventory-service
+      context: .
+      dockerfile: inventory-service/Dockerfile
     restart: always
     environment:
       - SPRING_PROFILES_ACTIVE=docker

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/inventory-service/Dockerfile
+++ b/inventory-service/Dockerfile
@@ -1,12 +1,30 @@
-FROM eclipse-temurin:17.0.4.1_1-jre as builder
-WORKDIR extracted
-ADD build/libs/*.jar app.jar
-RUN java -Djarmode=layertools -jar app.jar extract
+FROM azul/zulu-openjdk-alpine:25 AS builder
+WORKDIR /var/tmp/inventory-service
+COPY gradlew gradlew
+COPY gradle/wrapper gradle/wrapper
 
-FROM eclipse-temurin:17.0.4.1_1-jre
-WORKDIR application
-COPY --from=builder extracted/dependencies/ ./
-COPY --from=builder extracted/spring-boot-loader/ ./
-COPY --from=builder extracted/snapshot-dependencies/ ./
-COPY --from=builder extracted/application/ ./
-ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+RUN ./gradlew --version
+COPY build.gradle .
+COPY settings.gradle .
+COPY api-gateway/build.gradle api-gateway/build.gradle
+COPY discovery-server/build.gradle discovery-server/build.gradle
+COPY inventory-service/build.gradle inventory-service/build.gradle
+COPY order-service/build.gradle order-service/build.gradle
+COPY product-service/build.gradle product-service/build.gradle
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :inventory-service:dependencies --no-daemon --parallel --build-cache
+
+COPY inventory-service/src inventory-service/src
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :inventory-service:bootJar --no-daemon --parallel --build-cache
+RUN java -Djarmode=tools -jar inventory-service/build/libs/inventory-service.jar extract --destination extracted
+
+FROM azul/zulu-openjdk-alpine:25-jre
+WORKDIR /root
+COPY --from=builder /var/tmp/inventory-service/extracted/inventory-service.jar ./
+COPY --from=builder /var/tmp/inventory-service/extracted/lib ./lib
+
+EXPOSE 8080
+CMD ["java", "-jar", "./inventory-service.jar"]

--- a/order-service/Dockerfile
+++ b/order-service/Dockerfile
@@ -1,12 +1,30 @@
-FROM eclipse-temurin:17.0.4.1_1-jre as builder
-WORKDIR extracted
-ADD build/libs/*.jar app.jar
-RUN java -Djarmode=layertools -jar app.jar extract
+FROM azul/zulu-openjdk-alpine:25 AS builder
+WORKDIR /var/tmp/order-service
+COPY gradlew gradlew
+COPY gradle/wrapper gradle/wrapper
 
-FROM eclipse-temurin:17.0.4.1_1-jre
-WORKDIR application
-COPY --from=builder extracted/dependencies/ ./
-COPY --from=builder extracted/spring-boot-loader/ ./
-COPY --from=builder extracted/snapshot-dependencies/ ./
-COPY --from=builder extracted/application/ ./
-ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+RUN ./gradlew --version
+COPY build.gradle .
+COPY settings.gradle .
+COPY api-gateway/build.gradle api-gateway/build.gradle
+COPY discovery-server/build.gradle discovery-server/build.gradle
+COPY inventory-service/build.gradle inventory-service/build.gradle
+COPY order-service/build.gradle order-service/build.gradle
+COPY product-service/build.gradle product-service/build.gradle
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :order-service:dependencies --no-daemon --parallel --build-cache
+
+COPY order-service/src order-service/src
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :order-service:bootJar --no-daemon --parallel --build-cache
+RUN java -Djarmode=tools -jar order-service/build/libs/order-service.jar extract --destination extracted
+
+FROM azul/zulu-openjdk-alpine:25-jre
+WORKDIR /root
+COPY --from=builder /var/tmp/order-service/extracted/order-service.jar ./
+COPY --from=builder /var/tmp/order-service/extracted/lib ./lib
+
+EXPOSE 8080
+CMD ["java", "-jar", "./order-service.jar"]

--- a/product-service/Dockerfile
+++ b/product-service/Dockerfile
@@ -1,12 +1,30 @@
-FROM eclipse-temurin:17.0.4.1_1-jre as builder
-WORKDIR extracted
-ADD build/libs/*.jar app.jar
-RUN java -Djarmode=layertools -jar app.jar extract
+FROM azul/zulu-openjdk-alpine:25 AS builder
+WORKDIR /var/tmp/product-service
+COPY gradlew gradlew
+COPY gradle/wrapper gradle/wrapper
 
-FROM eclipse-temurin:17.0.4.1_1-jre
-WORKDIR application
-COPY --from=builder extracted/dependencies/ ./
-COPY --from=builder extracted/spring-boot-loader/ ./
-COPY --from=builder extracted/snapshot-dependencies/ ./
-COPY --from=builder extracted/application/ ./
-ENTRYPOINT ["java", "org.springframework.boot.loader.JarLauncher"]
+RUN ./gradlew --version
+COPY build.gradle .
+COPY settings.gradle .
+COPY api-gateway/build.gradle api-gateway/build.gradle
+COPY discovery-server/build.gradle discovery-server/build.gradle
+COPY inventory-service/build.gradle inventory-service/build.gradle
+COPY order-service/build.gradle order-service/build.gradle
+COPY product-service/build.gradle product-service/build.gradle
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :product-service:dependencies --no-daemon --parallel --build-cache
+
+COPY product-service/src product-service/src
+
+RUN --mount=type=cache,target=/root/.gradle \
+    ./gradlew :product-service:bootJar --no-daemon --parallel --build-cache
+RUN java -Djarmode=tools -jar product-service/build/libs/product-service.jar extract --destination extracted
+
+FROM azul/zulu-openjdk-alpine:25-jre
+WORKDIR /root
+COPY --from=builder /var/tmp/product-service/extracted/product-service.jar ./
+COPY --from=builder /var/tmp/product-service/extracted/lib ./lib
+
+EXPOSE 8080
+CMD ["java", "-jar", "./product-service.jar"]

--- a/run-project.sh
+++ b/run-project.sh
@@ -1,4 +1,1 @@
-./gradlew clean
-./gradlew bootjar
-docker-compose build
-docker-compose up -d
+docker compose up -d --build


### PR DESCRIPTION
## Summary

- Upgraded all core platform dependencies to their latest versions
- Fixed Spring Security DSL breaking changes introduced in Spring Security 6+
- Updated Spring Cloud Gateway artifact name to match the new naming convention in 5.x

## Version Changes

| Component | Before | After |
|---|---|---|
| Gradle | 7.6 | 9.4.1 |
| Java toolchain | 17 | 25 |
| Spring Boot | 3.0.2 | 4.0.5 |
| Spring Cloud | 2022.0.0 | 2025.1.1 |
| dependency-management plugin | 1.1.0 | 1.1.7 |
| `spring-cloud-starter-gateway` | old artifact | renamed to `spring-cloud-starter-gateway-server-webflux` |
| `SecurityConfig` | `.httpBasic().disable()` style | updated to `Customizer` lambda style |

## Test plan

- [x] `./gradlew compileJava` passes successfully on all subprojects

🤖 Generated with [Claude Code](https://claude.com/claude-code)